### PR TITLE
[PES-965] Continue to parse with error code 'ParseFailed'.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+before_install:
+  - gem update bundler
+
 language: ruby
 rvm:
   - '2.1.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.4.0
+* Allow error code 'ParseFailed' in response.
+
 # 1.3.0
 
 * Replace rest-client usage with net/http.

--- a/lib/hexillion.rb
+++ b/lib/hexillion.rb
@@ -54,9 +54,9 @@ module Hexillion
       doc = Nokogiri::XML(xml)
 
       records = doc.xpath(
-        <<~XPATH
+        <<-XPATH
           .//QueryResult[
-            ErrorCode='Success' and
+            (ErrorCode='Success' or ErrorCode='ParseFailed') and
             FoundMatch='Yes'
           ]/WhoisRecord
         XPATH

--- a/lib/hexillion.rb
+++ b/lib/hexillion.rb
@@ -52,7 +52,15 @@ module Hexillion
 
     def parse_xml(xml)
       doc = Nokogiri::XML(xml)
-      records = doc.xpath(".//QueryResult[ErrorCode='Success' and FoundMatch='Yes']/WhoisRecord")
+
+      records = doc.xpath(
+        <<~XPATH
+          .//QueryResult[
+            ErrorCode='Success' and
+            FoundMatch='Yes'
+          ]/WhoisRecord
+        XPATH
+      )
 
       strings = {
         registrant_name: "Registrant Name",

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -134,5 +134,19 @@ describe Hexillion::Client do
 
       expect(@hex.whois("example.com")[:xml_response]).to eq(xml)
     end
+
+    it "allows error code 'ParseFailed' in response" do
+      @response_body = <<-XML
+        <QueryResult><ErrorCode>ParseFailed</ErrorCode><FoundMatch>Yes</FoundMatch><WhoisRecord>
+          <Registrant>
+            <Address>48 Cambridge Street</Address>
+            <Address>Level 3</Address>
+            <Email>me@example.com</Email>
+          </Registrant>
+        </WhoisRecord></QueryResult>
+      XML
+
+      expect(@hex.whois("example.com")[:registrant_email]).to eq("me@example.com")
+    end
   end
 end


### PR DESCRIPTION
Background Context
------------------
The Hexillion documentation states the following:

> Parsing happens in several stages, so there may be useful parsed data in the result even if part of the parsing fails, yielding a ParseFailed error. It’s important to actually look for the fields you want in the response rather than simply relying on the value of ErrorCode.

What’s this do?
---------------
With this change, if the API returns the error code 'ParseFailed', we will still attempt to parse the XML response.